### PR TITLE
Fix calculation mistake

### DIFF
--- a/blur_wavelet.py
+++ b/blur_wavelet.py
@@ -34,7 +34,7 @@ def blur_detect(img, threshold):
     # Construct the edge map in each scale Step 2
     E1 = np.sqrt(np.power(LH1, 2)+np.power(HL1, 2)+np.power(HH1, 2))
     E2 = np.sqrt(np.power(LH2, 2)+np.power(HL2, 2)+np.power(HH2, 2))
-    E3 = np.sqrt(np.power(LH3, 2)+np.power(LH3, 2)+np.power(HH3, 2))
+    E3 = np.sqrt(np.power(LH3, 2)+np.power(HL3, 2)+np.power(HH3, 2))
     
     M1, N1 = E1.shape
 

--- a/blur_wavelet.py
+++ b/blur_wavelet.py
@@ -156,11 +156,11 @@ def blur_detect(img, threshold):
     Per = np.sum(DAstructure)/np.sum(EdgePoint)
     
     # Step 7
-    if np.sum(RSstructure) == 0:
+    if (np.sum(RGstructure) + np.sum(RSstructure)) == 0:
         
         BlurExtent = 100
     else:
-        BlurExtent = np.sum(BlurC)/np.sum(RSstructure)
+        BlurExtent = np.sum(BlurC) / (np.sum(RGstructure) + np.sum(RSstructure))
     
     return Per, BlurExtent
 


### PR DESCRIPTION
There are two fixes. The first is E3 calculation based on #3. The second one is regarding the calculation of `BlurExtent`. Based on the paper, Step 4 should be calculating `Nrg` by totaling the Rule 3 and Rule 4, i.e. the `RGstructure` and `RSstructure`.

The paper said as well that the blur extent is a confidence based on some percentage. As you can see on the image below, the fixed `BlurExtent` calculation is nicely on range [0,1] while the `Per` score is a bit different (caused by the fix).
<img width="815" alt="image" src="https://user-images.githubusercontent.com/22237301/99707694-6241ac00-2acf-11eb-8499-91a4c8f96579.png">
